### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ git clone https://github.com/zhongfly/telegram-bot-asf.git
 4,如使用socks代理，按注释修改requirments  
 5,安装依赖
 ```shell
-pip install -r requirements.txt  
+pip3 install -r requirements.txt  
 ```
 6,修改配置文件tgbot.toml  
 7,运行telegram-asf.py（使用默认配置文件路径）  

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ python3 telegram-asf.py YOUR_CONFIG.toml
 ```ini
 [telegram]
 token = "987654321:XXXXXX-XXXXXXXXXXXXXXXXXXXXXXXXXXXX"
-# 多位管理员用逗号隔开，例如[123456789,987654321,4564649]
+# 多位管理员用逗号隔开，例如[123456789,987654321,4564649]；此处需填入你自己的而非bot的telegram数字id(telegram中使用bot：userinfobot以获取您的数字id)。
 admin = [123456789]
 # socks5代理如下示例；http代理则类似填入"http://127.0.0.1:3128"；不使用代理则留空，只保留引号""
 proxy =  "socks5h://127.0.0.1:1080/"


### PR DESCRIPTION
在3.6与2.7python版本并存环境（ubuntu默认环境）时
执行pip install python-telegram-bot会安装到python2.7版本下
会导致在执行python3 telegram-asf.py时报错
```
Traceback (most recent call last):
  File "telegram-asf.py", line 3, in <module>
    from telegram.ext import Updater, CommandHandler, MessageHandler, Filters, Job, CallbackQueryHandler, ConversationHandler
ModuleNotFoundError: No module named 'telegram'

```
